### PR TITLE
Fix problem in os x 10.9.2

### DIFF
--- a/libraries/wbInterface/src/wbInterface.cpp
+++ b/libraries/wbInterface/src/wbInterface.cpp
@@ -22,7 +22,6 @@
 
 #include "wbInterface.h"
 #include <wbiIcub/wholeBodyInterfaceIcub.h>
-#include <bits/basic_string.h>
 // MASK PARAMETERS --------------------------------------
 #define NPARAMS            4                                // Number of input parameters
 #define BLOCK_TYPE_IDX     0                                // Index number for first input parameter


### PR DESCRIPTION
I had to remove this header inclusion to compile on OS X 10.9.2 . Is this a spurious inclusion or it was something actually needed? 
@francesco-romano @jeljaik 
