### PR TITLE
Added default value ... for FROM field

### DIFF
--- a/libraries/WBCLibrary.mdl
+++ b/libraries/WBCLibrary.mdl
@@ -2688,7 +2688,7 @@ Library {
 	  MaskTunableValueString  "on,on,on,on,on,on"
 	  MaskCallbackString	  "|||||autoconnect_val = get_param(gcb, 'Autoconnect');\nif(strcmp(autoconnect_val, 'on'))\n   "
 	  " set_param(gcb, 'MaskVisibilities',{'on';'off';'on';'on';'on';'on'});\n    set_param(gcb, 'to', '''...''');\nelse\n"
-	  "    set_param(gcb, 'MaskVisibilities',{'off';'on';'on';'on';'on';'on'});\nend"
+	  "    set_param(gcb, 'MaskVisibilities',{'off';'on';'on';'on';'on';'on'});\n    set_param(gcb, 'from', '''...''');\nend"
 	  MaskEnableString	  "on,on,on,on,on,on"
 	  MaskVisibilityString	  "on,off,on,on,on,on"
 	  MaskToolTipString	  "on,on,on,on,on,on"


### PR DESCRIPTION
Fixed issues commented in  https://github.com/robotology-playground/WBI-Toolbox/issues/83#issuecomment-87736511.
If we :
1. uncheck "Autoconnect" while the field `from` is empty
2. fill something in the field `to`
3. click OK
`from` field is automatically filled with the default port "...".